### PR TITLE
修改 CMSIS 默认定时器为硬件定时器

### DIFF
--- a/src/cmsis_rtthread.c
+++ b/src/cmsis_rtthread.c
@@ -11,7 +11,7 @@
 
 #include <cmsis_os2.h>
 #include "cmsis_rtthread.h"
-
+#include "board.h"
 #include <rthw.h>
 
 /// Kernel Information
@@ -187,6 +187,13 @@ uint32_t osKernelGetTickFreq(void)
 {
 
     return RT_TICK_PER_SECOND;
+}
+
+/// The function osKernelGetSysTimerCount returns the current RTOS kernel system timer as a 32-bit value.
+/// \return RTOS kernel current system timer count as 32-bit value.
+uint32_t osKernelGetSysTimerCount(void)
+{
+    return (uint32_t)SysTick->VAL;
 }
 
 /// Get the RTOS kernel system timer frequency.

--- a/src/cmsis_rtthread.c
+++ b/src/cmsis_rtthread.c
@@ -942,7 +942,7 @@ osTimerId_t osTimerNew(osTimerFunc_t func, osTimerType_t type, void *argument, c
     timer_cb_t *timer_cb;
     char name[RT_NAME_MAX];
     static rt_uint16_t timer_number = 0U;
-    rt_uint8_t flag = RT_TIMER_FLAG_SOFT_TIMER;
+    rt_uint8_t flag = RT_TIMER_FLAG_HARD_TIMER;
 
     /* Check parameters */
     if ((RT_NULL == func) || ((type != osTimerOnce) && (type != osTimerPeriodic)))


### PR DESCRIPTION
在当前 CMSIS 代码中定时器回调函数是在线程的上下文环境实现的，所以修改定时器为硬件定时器， 使定时器回调函数在中断上下文中实现。